### PR TITLE
Add dash separated package `sphinx-rtd-theme`

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+target_platform:
+- linux-64

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sphinx--rtd--theme-green.svg)](https://anaconda.org/conda-forge/sphinx-rtd-theme) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sphinx-rtd-theme.svg)](https://anaconda.org/conda-forge/sphinx-rtd-theme) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sphinx-rtd-theme.svg)](https://anaconda.org/conda-forge/sphinx-rtd-theme) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sphinx-rtd-theme.svg)](https://anaconda.org/conda-forge/sphinx-rtd-theme) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-sphinx_rtd_theme-green.svg)](https://anaconda.org/conda-forge/sphinx_rtd_theme) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sphinx_rtd_theme.svg)](https://anaconda.org/conda-forge/sphinx_rtd_theme) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sphinx_rtd_theme.svg)](https://anaconda.org/conda-forge/sphinx_rtd_theme) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sphinx_rtd_theme.svg)](https://anaconda.org/conda-forge/sphinx_rtd_theme) |
 
 Installing sphinx_rtd_theme
@@ -46,41 +47,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `sphinx_rtd_theme` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `sphinx-rtd-theme, sphinx_rtd_theme` can be installed with `conda`:
 
 ```
-conda install sphinx_rtd_theme
-```
-
-or with `mamba`:
-
-```
-mamba install sphinx_rtd_theme
-```
-
-It is possible to list all of the versions of `sphinx_rtd_theme` available on your platform with `conda`:
-
-```
-conda search sphinx_rtd_theme --channel conda-forge
+conda install sphinx-rtd-theme sphinx_rtd_theme
 ```
 
 or with `mamba`:
 
 ```
-mamba search sphinx_rtd_theme --channel conda-forge
+mamba install sphinx-rtd-theme sphinx_rtd_theme
+```
+
+It is possible to list all of the versions of `sphinx-rtd-theme` available on your platform with `conda`:
+
+```
+conda search sphinx-rtd-theme --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search sphinx-rtd-theme --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search sphinx_rtd_theme --channel conda-forge
+mamba repoquery search sphinx-rtd-theme --channel conda-forge
 
-# List packages depending on `sphinx_rtd_theme`:
-mamba repoquery whoneeds sphinx_rtd_theme --channel conda-forge
+# List packages depending on `sphinx-rtd-theme`:
+mamba repoquery whoneeds sphinx-rtd-theme --channel conda-forge
 
-# List dependencies of `sphinx_rtd_theme`:
-mamba repoquery depends sphinx_rtd_theme --channel conda-forge
+# List dependencies of `sphinx-rtd-theme`:
+mamba repoquery depends sphinx-rtd-theme --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,35 +1,49 @@
 {% set version = "1.1.1" %}
 {% set sha256 = "6146c845f1e1947b3c3dd4432c28998a1693ccc742b4f9ad7c63129f0757c103" %}
-{% set pkg_name = "sphinx_rtd_theme" %}		
+{% set name = "sphinx_rtd_theme" %}
 
 package:
-  name: {{ pkg_name }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ pkg_name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ pkg_name[0] }}/{{ pkg_name }}/{{ pkg_name }}-{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1
 
-requirements:
-  host:
-    - pip
-    - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
-    - setuptools
-    - sphinx >=1.6,<6
-  run:
-    - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
-    - sphinx >=1.6,<6
-    - docutils <0.18
+outputs:
+  - name: {{ name }}
+    build:
+      script: python -m pip install . --no-deps -vv
+      noarch: python
 
-test:
-  imports:
-    - sphinx_rtd_theme
+    requirements:
+      host:
+        - pip
+        - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+        - setuptools
+        - sphinx >=1.6,<6
+      run:
+        - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+        - sphinx >=1.6,<6
+        - docutils <0.18
+
+    test:
+      imports:
+        - sphinx_rtd_theme
+
+  - name: sphinx-rtd-theme
+    build:
+      noarch: python
+    requirements:
+      run:
+        - {{ pin_subpackage(name, exact=True) }}
+    test:
+      imports:
+        - sphinx_rtd_theme
 
 about:
   home: https://github.com/readthedocs/sphinx_rtd_theme/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

## Context

There is only `sphinx_rtd_theme` package on `conda-forge`. While `pip` accepts both underline-separate `sphinx_rtd_theme` and dash-separate `sphinx-rtd-theme` package names:

```bash
pip3 install sphinx_rtd_theme
pip3 install sphinx-rtd-theme
```

See also [`conda-forge/typing_extensions-feedstock`](https://github.com/conda-forge/typing_extensions-feedstock):

https://github.com/conda-forge/typing_extensions-feedstock/blob/07de5982a700e9d2b1d549037eef37ea5a19e761/recipe/meta.yaml#L15-L41

which generates both `typing_extensions` and `typing-extensions`.
