### PR TITLE
unpin docutils and bump build number to 1 for v1.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}
@@ -29,7 +29,7 @@ outputs:
       run:
         - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
         - sphinx >=1.6,<7
-        - docutils <0.19
+        - docutils
         - sphinxcontrib-jquery >=2.0.0,!=3.0.0  # [py>=3]
 
     test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* ~[ ] Reset the build number to `0` (if the version changed)~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Following on from https://github.com/conda-forge/sphinx_rtd_theme-feedstock/issues/28 I am proposing to unpin `docutils` so that `sphinx_rtd_theme` build=1 of version 1.2.0 allows support for the latest `sphinx` and `python=3.11`. Note that I am not aware of the reason for the pin, so I might be completely wrong unpinning it, but from a purely dependency analysis point of view, this would be useful. Cheers :beer: 
